### PR TITLE
Support multiple heating circuits, boilers, etc

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,28 +10,24 @@ This integration has been tested with Solarfocus eco<sup>manager-touch</sup> ver
 
 | Components | Supported |
 |---|---|
-| Heating Circuit 1 (_Heizkreis_)| :white_check_mark: |
-| Buffer 1 (_Puffer_) | :white_check_mark: |
+| Heating Circuits (_Heizkreis_)| :white_check_mark: |
+| Buffers (_Puffer_) | :white_check_mark: |
 | Solar (_Solar_)| :x:|
-| Boiler 1 (_Boiler_) | :white_check_mark: |
+| Boilers (_Boiler_) | :white_check_mark: |
 | Heatpump (_Wärmepumpe_) | :white_check_mark: |
 | Biomassboiler (_Kessel_) | :white_check_mark: | 
 
-_Note: The number of supported Heating Circuits, Buffers, and Boilers could be extended in the future_
+_Note: Different components or heating systems could be supported in the future_
 
 ## Usage
 
 ```python
-from pymodbus.client import ModbusTcpClient as ModbusClient
-from pysolarfocus import SolarfocusAPI,PORT,Systems
-
-# Create a Modbus client
-client = ModbusClient(IP, port=PORT)
-client.connect()
+from pysolarfocus import SolarfocusAPI,Systems
 
 # Create the Solarfocus API client
-solarfocus = SolarfocusAPI(client, Systems.Vampair)
-
+solarfocus = SolarfocusAPI(ip=[Your-IP],system=Systems.Vampair)
+# Connect to the heating system
+solarfocus.connect() 
 # Fetch the values
 solarfocus.update()
 
@@ -39,3 +35,26 @@ solarfocus.update()
 print(solarfocus.buffer)
 print(solarfocus.heating_circuit)
 ```
+
+### Handling multiple components e.g. heating circuits
+_Solarfocus systems allow the use of multiple heating circuits, buffers and boilers. The api can be configured to interact with multiple components._
+
+```python 
+
+# Create the Solarfocus API client with 2 Heating Circuits
+solarfocus = SolarfocusAPI(ip=[Your-IP],heating_circuit_count=2,system=Systems.Vampair)
+# Connect to the heating system
+solarfocus.connect()
+
+# Update all heating circuits
+solarfocus.update_heating()
+
+# Update only the first heating circuit
+solarfocus.heating_circuits[0].update()
+# Print the first heating circuit
+print(solarfocus.heating_circuits[0])
+
+# Set the temperature of the first heating circuit to 30°C
+solarfocus.heating_circuits[0].indoor_temperatur_external.set_unscaled_value(30)
+# Write the value to the heating system
+solarfocus.heating_circuits[0].indoor_temperatur_external.commit()

--- a/example.py
+++ b/example.py
@@ -2,7 +2,7 @@ from pysolarfocus import SolarfocusAPI, PORT,Systems
 
 # Create the Solarfocus API client
 # TODO: Adapt IP-Address
-solarfocus = SolarfocusAPI("IP-Address", Systems.Therminator)
+solarfocus = SolarfocusAPI(ip="IP-Address", system=Systems.Vampair)
 solarfocus.connect()
 # Fetch the values
 solarfocus.update()

--- a/example.py
+++ b/example.py
@@ -1,14 +1,9 @@
-from pymodbus.client.sync import ModbusTcpClient as ModbusClient
 from pysolarfocus import SolarfocusAPI, PORT,Systems
 
-# Create a Modbus client 
-# TODO: Adapt IP-Address
-client = ModbusClient("IP-Address", port=PORT) 
-client.connect()
-
 # Create the Solarfocus API client
-solarfocus = SolarfocusAPI(client, Systems.Vampair)
-
+# TODO: Adapt IP-Address
+solarfocus = SolarfocusAPI("IP-Address", Systems.Therminator)
+solarfocus.connect()
 # Fetch the values
 solarfocus.update()
 

--- a/pysolarfocus/__init__.py
+++ b/pysolarfocus/__init__.py
@@ -298,21 +298,46 @@ class SolarfocusAPI:
     @property
     def system(self): 
         return self._system
-
-
-    def __init__(self,ip:str,system:Systems=Systems.Vampair,port:int=PORT,slave_id:int=SLAVE_ID):
+    
+    def __init__(self,
+                 ip:str,
+                 heating_circuit_count:int = 1,
+                 buffer_count:int = 1,
+                 boiler_count:int = 1,
+                 system:Systems=Systems.Vampair,
+                 port:int=PORT,
+                 slave_id:int=SLAVE_ID):
         """Initialize Solarfocus communication."""
+        assert heating_circuit_count >= 1 and heating_circuit_count < 9, "Heating circuit count must be between 1 and 8"
+        assert buffer_count >= 1 and buffer_count < 5, "Buffer count must be between 1 and 4"
+        assert boiler_count >= 1 and boiler_count < 5, "Boiler count must be between 1 and 4"
+        
         self.__conn = ModbusConnector(ip,port,slave_id)
         self.__factory = ComponentFactory(self.__conn)
-        self.heating_circuit = self.__factory.heating_circuit(system)
-        self.boiler = self.__factory.boiler(system)
+        #Lists of components
+        self.heating_circuits = self.__factory.heating_circuit(system,heating_circuit_count)
+        self.boilers = self.__factory.boiler(system,boiler_count)
+        self.buffers = self.__factory.buffer(system,buffer_count)
+        #Single components
         self.heatpump = self.__factory.heatpump(system)
         self.photovoltaic = self.__factory.photovoltaic(system)
         self.pelletsboiler = self.__factory.pelletsboiler(system)
-        self.buffer = self.__factory.buffer(system)
         self._slave_id = slave_id
         self._system = system
 
+    #These are needed to keep compatability with the old getter Api
+    @property
+    def heating_circuit(self):
+        return self.heating_circuits[0]
+    
+    @property
+    def boiler(self):
+        return self.boilers[0]
+    
+    @property
+    def buffer(self):
+        return self.buffers[0]
+    
     def connect(self):
         """Connect to Solarfocus eco manager-touch"""
         return self.__conn.connect()
@@ -337,15 +362,24 @@ class SolarfocusAPI:
 
     def update_heating(self) -> bool:
         """Read values from Heating System"""
-        return self.heating_circuit.update()
+        for heating_circuit in self.heating_circuits:
+            if not heating_circuit.update():
+                return False
+        return True
     
     def update_buffer(self) -> bool:
         """Read values from Heating System"""
-        return self.buffer.update()
+        for buffer in self.buffers:
+            if not buffer.update():
+                return False
+        return True
     
     def update_boiler(self) -> bool:
         """Read values from Heating System"""
-        return self.boiler.update()
+        for boiler in self.boilers:
+            if not boiler.update():
+                return False
+        return True
 
     def update_heatpump(self) -> bool:
         """Read values from Heating System"""

--- a/pysolarfocus/__init__.py
+++ b/pysolarfocus/__init__.py
@@ -4,8 +4,6 @@ __version__ = "2.0.5"
 import logging
 from enum import Enum
 
-from pymodbus.client.sync import ModbusTcpClient
-
 #Default port for modbus
 PORT = 502
 
@@ -17,6 +15,7 @@ class Systems(str, Enum):
     Vampair = "Vampair"
     Therminator = "Therminator" 
     
+from .modbus_wrapper import ModbusConnector
 from .component_factory import ComponentFactory
 from .components.base.component import Component
 from .components.base.data_value import DataValue
@@ -61,7 +60,7 @@ class SolarfocusAPI:
 
     @property
     def hc1_target_temperatur(self) -> float:
-        return self.heating_circuit.target_supply_temperature.reverse_scaled_value
+        return self.heating_circuit.target_supply_temperature.scaled_value
 
     @property
     def hc1_cooling(self) -> int:
@@ -73,7 +72,7 @@ class SolarfocusAPI:
 
     @property
     def hc1_target_room_temperatur(self) -> float:
-        return self.heating_circuit.target_room_temperatur.reverse_scaled_value
+        return self.heating_circuit.target_room_temperatur.scaled_value
 
     @property
     def hc1_indoor_temperature_external(self) -> float:
@@ -117,7 +116,7 @@ class SolarfocusAPI:
 
     @property
     def bo1_target_temperatur(self) -> float:
-        return self.boiler.target_temperature.reverse_scaled_value
+        return self.boiler.target_temperature.scaled_value
 
     @property
     def bo1_single_charge(self) -> int:
@@ -222,7 +221,7 @@ class SolarfocusAPI:
 
     @property
     def hp_outdoor_temperature_external(self) -> float:
-        return self.heatpump.outdoor_temperature_external.reverse_scaled_value
+        return self.heatpump.outdoor_temperature_external.scaled_value
     
     @property
     def pv_power(self) -> int:
@@ -301,26 +300,27 @@ class SolarfocusAPI:
         return self._system
 
 
-    def __init__(self, conn:ModbusTcpClient,system:Systems=Systems.Vampair,slave_id:int=SLAVE_ID):
+    def __init__(self,ip:str,system:Systems=Systems.Vampair,port:int=PORT,slave_id:int=SLAVE_ID):
         """Initialize Solarfocus communication."""
-        self._conn = conn
-        self.heating_circuit = ComponentFactory.heating_circuit(system)
-        self.boiler = ComponentFactory.boiler(system)
-        self.heatpump = ComponentFactory.heatpump(system)
-        self.photovoltaic = ComponentFactory.photovoltaic(system)
-        self.pelletsboiler = ComponentFactory.pelletsboiler(system)
-        self.buffer = ComponentFactory.buffer(system)
+        self.__conn = ModbusConnector(ip,port,slave_id)
+        self.__factory = ComponentFactory(self.__conn)
+        self.heating_circuit = self.__factory.heating_circuit(system)
+        self.boiler = self.__factory.boiler(system)
+        self.heatpump = self.__factory.heatpump(system)
+        self.photovoltaic = self.__factory.photovoltaic(system)
+        self.pelletsboiler = self.__factory.pelletsboiler(system)
+        self.buffer = self.__factory.buffer(system)
         self._slave_id = slave_id
         self._system = system
 
     def connect(self):
         """Connect to Solarfocus eco manager-touch"""
-        return self._conn.connect()
+        return self.__conn.connect()
 
     @property
     def is_connected(self)->bool:
         """Check if connection is established"""
-        return self._conn.is_socket_open()
+        return self.__conn.is_connected
     
     def update(self):
         """Read values from Heating System"""
@@ -337,160 +337,99 @@ class SolarfocusAPI:
 
     def update_heating(self) -> bool:
         """Read values from Heating System"""
-        return self.__update(self.heating_circuit)
+        return self.heating_circuit.update()
     
     def update_buffer(self) -> bool:
         """Read values from Heating System"""
-        return self.__update(self.buffer)
+        return self.buffer.update()
     
     def update_boiler(self) -> bool:
         """Read values from Heating System"""
-        return self.__update(self.boiler)
+        return self.boiler.update()
 
     def update_heatpump(self) -> bool:
         """Read values from Heating System"""
-        return self.__update(self.heatpump)
+        return self.heatpump.update()
 
     def update_photovoltaic(self) -> bool:
         """Read values from Heating System"""
-        return self.__update(self.photovoltaic)
+        return self.photovoltaic.update()
 
     def update_pelletsboiler(self) -> bool:
         """Read values from Pellets boiler"""
-        return self.__update(self.pelletsboiler)
-    
-    def __update(self,component:Component)->bool:
-        """Read values for the given component from Heating System"""
-        failed=False
-        if component.has_input_address:
-            read_success, registers = self.__read_input_registers(component)
-            parsing_success = False
-            if read_success:
-                parsing_success = component.parse(registers, RegisterTypes.Input) and read_success
-            failed = not parsing_success and read_success or failed
-             
-        if component.has_holding_address:
-            read_success, registers = self.__read_holding_registers(component)
-            parsing_success = False
-            if read_success:
-                parsing_success = component.parse(registers, RegisterTypes.Holding) and read_success
-            failed = not (parsing_success and read_success) or failed
-        return not failed
-    
+        return self.pelletsboiler.update()
     
     def hc1_set_target_supply_temperature(self, temperature) -> bool:
         """Set target supply temperature"""
-        return self.__write_register(self.heating_circuit.target_supply_temperature,temperature)
-
-
+        self.heating_circuit.target_supply_temperature.set_unscaled_value(temperature)
+        return self.heating_circuit.target_supply_temperature.commit()
+    
     def hc1_enable_cooling(self, cooling: bool) -> bool:
         """Set target supply temperature"""
-        return self.__write_register(self.heating_circuit.cooling,cooling)
+        self.heating_circuit.cooling.set_unscaled_value(cooling)
+        return self.heating_circuit.cooling.commit()
     
     def hc1_set_mode(self, mode: int) -> bool:
         """Set mode"""
-        return self.__write_register(self.heating_circuit.mode,mode)
-
+        self.heating_circuit.mode.set_unscaled_value(mode)
+        return self.heating_circuit.mode.commit()
+    
     def hc1_set_target_room_temperature(self, temperature: float) -> bool:
         """Set target room temperature"""
-        return self.__write_register(self.heating_circuit.target_room_temperatur,temperature)
+        self.heating_circuit.target_room_temperatur.set_unscaled_value(temperature)
+        return self.heating_circuit.target_room_temperatur.commit()
     
     def hc1_set_indoor_temperature(self, temperature: float) -> bool:
         """Set indoor temperature"""
-        return self.__write_register(self.heating_circuit.indoor_temperatur_external,temperature)
+        self.heating_circuit.indoor_temperatur_external.set_unscaled_value(temperature)
+        return self.heating_circuit.indoor_temperatur_external.commit()
     
     def hc1_set_indoor_humidity(self, humidity: float) -> bool:
         """Set indoor humidity"""
-        return self.__write_register(self.heating_circuit.indoor_humidity_external,int(humidity))
+        self.heating_circuit.indoor_humidity_external.set_unscaled_value(humidity)
+        return self.heating_circuit.indoor_humidity_external.commit()
     
     def bo1_set_target_temperature(self, temperature: float) -> bool:
         """Set target temperature"""
-        return self.__write_register(self.boiler.target_temperature,temperature)
+        self.boiler.target_temperature.set_unscaled_value(temperature)
+        return self.boiler.target_temperature.commit()
     
     def bo1_enable_single_charge(self, enable: bool) -> bool:
         """Enable single charge"""
-        return self.__write_register(self.boiler.single_charge,int(enable))
+        self.boiler.single_charge.set_unscaled_value(enable)
+        return self.boiler.single_charge.commit()
     
     def bo1_set_mode(self, mode: int) -> bool:
         """Set mode"""
-        return self.__write_register(self.boiler.mode,mode)
+        self.boiler.mode.set_unscaled_value(mode)
+        return self.boiler.mode.commit()
     
     def bo1_enable_circulation(self, enable: bool) -> bool:
         """Enable circulation"""
-        return self.__write_register(self.boiler.circulation,int(enable))
+        self.boiler.circulation.set_unscaled_value(enable)
+        return self.boiler.circulation.commit()
 
     def hp_smart_grid_request_operation(self, operation_request: bool) -> bool:
         """Set Smart Grid value"""
-        return self.__write_register(self.heatpump.smart_grid, SMART_GRID_EINSCHALTUNG if operation_request else SMART_GRID_NORMALBETRIEB)
+        self.heatpump.smart_grid.set_unscaled_value(SMART_GRID_EINSCHALTUNG if operation_request else SMART_GRID_NORMALBETRIEB)
+        return self.heatpump.smart_grid.commit()
 
     def hp_set_outdoor_temperature(self, temperature: float) -> bool:
         """Set outdoor temperature"""
-        return self.__write_register(self.heatpump.outdoor_temperature_external,temperature)
+        self.heatpump.outdoor_temperature_external.set_unscaled_value(temperature)
+        return self.heatpump.outdoor_temperature_external.commit()
     
     def pv_set_smart_meter(self, value: int) -> bool:
         """Set Smart Meter"""
-        return self.__write_register(self.photovoltaic.smart_meter,value)
+        self.photovoltaic.smart_meter.set_unscaled_value(value)
+        return self.photovoltaic.smart_meter.commit()
 
     def pv_set_photovoltaic(self, value: int) -> bool:
         """Set Photovoltaic"""
-        return self.__write_register(self.photovoltaic.photovoltaic, value)
-
-
+        self.photovoltaic.photovoltaic.set_unscaled_value(value)
+        return self.photovoltaic.photovoltaic.commit()
+        
     def pv_set_grid_im_export(self, value: int) -> bool:
         """Set Photovoltaic"""
-        return self.__write_register(self.photovoltaic.grid_im_export,value)
-    
-    def __write_register(self,data_value:DataValue, value:float, check_connection:bool = True) -> bool:
-        """Internal methode to write a value to the modbus server"""
-        if check_connection and not self.is_connected:
-            logging.error("Connection to modbus is not established!")
-            return False
-        try:
-            scaled = int(data_value.scale(value))
-            logging.info(f"Scaled Value={scaled}")
-            response = self._conn.write_registers(data_value.get_absolute_address(), [scaled], unit=self._slave_id)
-            if response.isError():
-                logging.error(f"Error writing value={value} to register: {data_value.get_absolute_address()}: {response}")
-                return False
-        except Exception:
-            logging.exception(f"Eception while writing value={value} to register: {data_value.get_absolute_address()}!")
-            return False
-        return True
-
-    def __read_holding_registers(self,component:Component, check_connection:bool = True)->tuple[bool,list[int]]:
-        """Internal methode to read holding registers from modbus"""
-        if check_connection and not self.is_connected:
-            logging.error("Connection to modbus is not established!")
-            return False, None
-        try:
-            combined_result = [None] * component.holding_count
-            for registerSlice in component.holding_slices:
-                result = self._conn.read_holding_registers(address=registerSlice.absolute_address,count=registerSlice.count ,unit=self._slave_id)
-                if result.isError():
-                    logging.error(f"Modbus read error at address={registerSlice.absolute_address}: {result}")
-                    return False, None
-                slice_data = result.registers
-                combined_result[registerSlice.relative_address:registerSlice.relative_address+registerSlice.count] = slice_data
-            return True, combined_result
-        except Exception:
-            logging.exception(f"Exception while reading holding registers for component: '{component.__class__.__name__}'!")
-            return False, None
-        
-    def __read_input_registers(self,component:Component,check_connection:bool=True)->tuple[bool,list[int]]:
-        """Internal methode to read input registers from modbus"""
-        if check_connection and not self.is_connected:
-            logging.error("Connection to modbus is not established!")
-            return False, None
-        try:
-            combined_result = [None] * component.input_count
-            for registerSlice in component.input_slices:
-                result = self._conn.read_input_registers(address=registerSlice.absolute_address,count=registerSlice.count,unit=self._slave_id)
-                if result.isError():
-                    logging.error(f"Modbus read error at address={registerSlice.absolute_address}, count={registerSlice.count}: {result}")
-                    return False, None
-                slice_data = result.registers
-                combined_result[registerSlice.relative_address:registerSlice.relative_address+registerSlice.count] = slice_data
-            return True, combined_result
-        except Exception:
-            logging.exception(f"Exception while reading input registers for component: '{component.__class__.__name__}'!")
-            return False, None
+        self.photovoltaic.grid_im_export.set_unscaled_value(value)
+        return self.photovoltaic.grid_im_export.commit()

--- a/pysolarfocus/component_factory.py
+++ b/pysolarfocus/component_factory.py
@@ -4,35 +4,33 @@ from .components.heat_pump import *
 from .components.buffer import *
 from .components.pellets_boiler import *
 from .components.photovoltaic import *
+from .modbus_wrapper import ModbusConnector
 from . import Systems
 
 
 class ComponentFactory:
-    @staticmethod
-    def heating_circuit(system:Systems)->HeatingCircuit:
+    def __init__(self,modbus_connector:ModbusConnector) -> None:
+        self.__modbus_connector = modbus_connector
+        
+    def heating_circuit(self, system:Systems)->HeatingCircuit:
         if system == Systems.Therminator:
-            return TherminatorHeatingCircuit()._initialize()
-        return HeatingCircuit()._initialize()
+            return TherminatorHeatingCircuit()._initialize(self.__modbus_connector)
+        return HeatingCircuit()._initialize(self.__modbus_connector)
     
-    @staticmethod
-    def boiler(system:Systems)->Boiler:
-        return Boiler()._initialize()
+    def boiler(self, system:Systems)->Boiler:
+        return Boiler()._initialize(self.__modbus_connector)
     
-    @staticmethod
-    def heatpump(system:Systems)->HeatPump:
-        return HeatPump()._initialize()
+    def heatpump(self, system:Systems)->HeatPump:
+        return HeatPump()._initialize(self.__modbus_connector)
     
-    @staticmethod
-    def photovoltaic(system:Systems)->Photovoltaic:
-        return Photovoltaic()._initialize()
+    def photovoltaic(self, system:Systems)->Photovoltaic:
+        return Photovoltaic()._initialize(self.__modbus_connector)
     
-    @staticmethod
-    def pelletsboiler(system:Systems)->PelletsBoiler:
-        return PelletsBoiler()._initialize()
+    def pelletsboiler(self, system:Systems)->PelletsBoiler:
+        return PelletsBoiler()._initialize(self.__modbus_connector)
     
-    @staticmethod
-    def buffer(system:Systems)->Buffer:
+    def buffer(self, system:Systems)->Buffer:
         if system == Systems.Therminator:
-            return TherminatorBuffer()._initialize()
+            return TherminatorBuffer()._initialize(self.__modbus_connector)
         else:
-            return Buffer()._initialize()
+            return Buffer()._initialize(self.__modbus_connector)

--- a/pysolarfocus/component_factory.py
+++ b/pysolarfocus/component_factory.py
@@ -12,14 +12,40 @@ class ComponentFactory:
     def __init__(self,modbus_connector:ModbusConnector) -> None:
         self.__modbus_connector = modbus_connector
         
-    def heating_circuit(self, system:Systems)->HeatingCircuit:
-        if system == Systems.Therminator:
-            return TherminatorHeatingCircuit()._initialize(self.__modbus_connector)
-        return HeatingCircuit()._initialize(self.__modbus_connector)
+    def heating_circuit(self, system:Systems,count:int)->list[HeatingCircuit]:
+        input_addresses = list(range(1100,1100+(50*count),50))
+        holding_addresses = list(range(32600,32600+(50*count),50))
+        heating_circuits = []
+        for i in range(count):
+            input,holding = input_addresses[i],holding_addresses[i]
+            if system == Systems.Therminator:
+                heating_circuit = TherminatorHeatingCircuit(input,holding)._initialize(self.__modbus_connector)
+            else:
+                heating_circuit = HeatingCircuit(input,holding)._initialize(self.__modbus_connector)
+            heating_circuits.append(heating_circuit)
+        return heating_circuits
     
-    def boiler(self, system:Systems)->Boiler:
-        return Boiler()._initialize(self.__modbus_connector)
+    def boiler(self, system:Systems,count:int)->list[Boiler]:
+        input_addresses = list(range(500,500+(50*count),50))
+        holding_addresses = list(range(32000,32000+(50*count),50))
+        boilers = []
+        for i in range(count):
+            input,holding = input_addresses[i],holding_addresses[i]
+            boilers.append(Boiler(input,holding)._initialize(self.__modbus_connector))
+        return boilers
     
+    def buffer(self, system:Systems,count:int)->list[Buffer]:
+        input_addresses = list(range(1900,1900+(20*count),20))
+        buffers = []
+        for i in range(count):
+            input = input_addresses[i]
+            if system == Systems.Therminator:
+                buffer = TherminatorBuffer(input)._initialize(self.__modbus_connector)
+            else:
+                buffer = Buffer(input)._initialize(self.__modbus_connector)
+            buffers.append(buffer)
+        return buffers
+        
     def heatpump(self, system:Systems)->HeatPump:
         return HeatPump()._initialize(self.__modbus_connector)
     
@@ -29,8 +55,3 @@ class ComponentFactory:
     def pelletsboiler(self, system:Systems)->PelletsBoiler:
         return PelletsBoiler()._initialize(self.__modbus_connector)
     
-    def buffer(self, system:Systems)->Buffer:
-        if system == Systems.Therminator:
-            return TherminatorBuffer()._initialize(self.__modbus_connector)
-        else:
-            return Buffer()._initialize(self.__modbus_connector)

--- a/pysolarfocus/components/base/data_value.py
+++ b/pysolarfocus/components/base/data_value.py
@@ -1,4 +1,9 @@
-from .enums import RegisterTypes,DataTypes
+import logging
+
+
+import logging
+from ...modbus_wrapper import ModbusConnector
+from .enums import DataTypes, RegisterTypes
 
 class DataValue(object):
     """
@@ -10,6 +15,7 @@ class DataValue(object):
     value:int
     multiplier:float
     _absolut_address:int
+    _modbus:ModbusConnector
     register_type:RegisterTypes
     def __init__(self,address:int,count:int=1,default_value:int=0,multiplier:float=None,type:DataTypes=DataTypes.INT,register_type:RegisterTypes=RegisterTypes.Input) -> None:
         self.address = address
@@ -17,8 +23,10 @@ class DataValue(object):
         self.value = default_value
         self.multiplier = multiplier
         self.type = type
-        self._absolut_address = None # This will be set by the parent component
         self.register_type = register_type
+        #These are set by the parent component
+        self._absolut_address = None 
+        self._modbus = None
         
     def get_absolute_address(self)->int:
         """
@@ -38,40 +46,40 @@ class DataValue(object):
         Scaled value of this register
         """
         if self.has_scaler:
-            return self.value * self.multiplier
+            #Input registers are scaled differently than holding registers
+            if self.register_type == RegisterTypes.Input:
+                return self.value * self.multiplier
+            else:
+                return self.value / self.multiplier
         else:
             return self.value
-        
-    @property
-    def reverse_scaled_value(self)->float:
-        """
-        Scaled value of this register
-        """
-        if self.has_scaler:
-            return self.value / self.multiplier
-        else:
-            return self.value
-       
+          
     def reverse_scale(self,value:float)->float:
         """
         Applies the scaler in the reverse direction
         """
         if self.has_scaler:
-            return value / self.multiplier
-        else:
-            return value
-        
-    def scale(self,value:float)->float:
-        """
-        Applies the scaler in the reverse direction
-        """
-        if self.has_scaler:
-            return value * self.multiplier
+            #Input registers are scaled differently than holding registers
+            if self.register_type == RegisterTypes.Input:
+                return value / self.multiplier
+            else:
+                return value * self.multiplier
         else:
             return value
         
     def set_unscaled_value(self,value:float)->None:
         """
-        Applies the scaler to the value and sets the value
+        Applies the reverse scaler to the value and sets the value
         """
         self.value = self.reverse_scale(value)
+        
+    def commit(self)->bool:
+        """
+        Writes the current value to the heating system
+        """
+        if self._modbus is None:
+            #Modbus is never set for input registers
+            return False
+        
+        logging.debug(f"Writing to server: Scaled Value={self.scaled_value}, Raw Value={int(self.value)}, Address={self.get_absolute_address()}")
+        return self._modbus.write_register(int(self.value),self.get_absolute_address())

--- a/pysolarfocus/components/boiler.py
+++ b/pysolarfocus/components/boiler.py
@@ -3,8 +3,8 @@ from .base.enums import DataTypes,RegisterTypes
 from .base.data_value import DataValue
 
 class Boiler(Component):
-    def __init__(self) -> None:
-        super().__init__(input_address=500, holding_address=32000)
+    def __init__(self,input_address:int=500, holding_address:int=32000) -> None:
+        super().__init__(input_address=input_address, holding_address=holding_address)
         self.temperature = DataValue(address=0,multiplier=0.1)
         self.state = DataValue(address=1,type=DataTypes.UINT)
         self.mode = DataValue(address=2,type=DataTypes.UINT)

--- a/pysolarfocus/components/buffer.py
+++ b/pysolarfocus/components/buffer.py
@@ -13,8 +13,8 @@ class Buffer(Component):
         
         
 class TherminatorBuffer(Buffer):
-    def __init__(self) -> None:
-        super().__init__(1900)
+    def __init__(self,address:int=1900) -> None:
+        super().__init__(address=address)
         self.x35_temperature = DataValue(address=2,multiplier=0.1)
         self.pump = DataValue(address=3)
         self.state = DataValue(address=4,type=DataTypes.UINT)

--- a/pysolarfocus/modbus_wrapper.py
+++ b/pysolarfocus/modbus_wrapper.py
@@ -1,0 +1,85 @@
+import logging
+try:
+    #modbus version < 3.0
+    from pymodbus.client.sync import ModbusTcpClient as ModbusClient
+    IS_LEGACY_VERSION = True
+except:
+    #modbus version >= 3.0
+    from pymodbus.client import ModbusTcpClient as ModbusClient
+    IS_LEGACY_VERSION = False
+from .components.base.register_slice import RegisterSlice
+  
+class ModbusConnector():
+    """
+    Helper methodes to read/write data to a modbus server
+    """
+    def __init__(self,ip:str,port:int,slave_id:int) -> None:
+        self.ip = ip
+        self.port = port
+        self.slave_id = slave_id
+        self.client = ModbusClient(ip,port=port)
+        self.__slave_args = {"unit":slave_id} if IS_LEGACY_VERSION else {"slave":slave_id}
+        
+    @property
+    def is_connected(self)->bool:
+        return self.client.is_socket_open()
+    
+    def connect(self)->bool:
+        return self.client.connect()
+
+  
+    def read_input_registers(self,slices:list[RegisterSlice],count:int,check_connection:bool=True)->tuple[bool,list[int]]:
+        """Internal methode to read input registers from modbus"""
+        if check_connection and not self.is_connected:
+            logging.error("Connection to modbus is not established!")
+            return False, None
+        try:
+            combined_result = [None] * count
+            for registerSlice in slices:
+                result = self.client.read_input_registers(address=registerSlice.absolute_address,count=registerSlice.count, **self.__slave_args)
+                if result.isError():
+                    logging.error(f"Modbus read error at address={registerSlice.absolute_address}, count={registerSlice.count}: {result}")
+                    return False, None
+                slice_data = result.registers
+                combined_result[registerSlice.relative_address:registerSlice.relative_address+registerSlice.count] = slice_data
+            return True, combined_result
+        except Exception:
+            logging.exception(f"Exception while reading input registers for address: '{slices[0].absolute_address}'!")
+            return False, None
+     
+    def read_holding_registers(self,slices:list[RegisterSlice],count:int, check_connection:bool = True)->tuple[bool,list[int]]:
+        """Internal methode to read holding registers from modbus"""
+        if check_connection and not self.is_connected:
+            logging.error("Connection to modbus is not established!")
+            return False, None
+        try:
+            combined_result = [None] * count
+            for registerSlice in slices:
+                result = self.client.read_holding_registers(address=registerSlice.absolute_address,count=registerSlice.count, **self.__slave_args)
+                if result.isError():
+                    logging.error(f"Modbus read error at address={registerSlice.absolute_address}: {result}")
+                    return False, None
+                slice_data = result.registers
+                combined_result[registerSlice.relative_address:registerSlice.relative_address+registerSlice.count] = slice_data
+            return True, combined_result
+        except Exception:
+            logging.exception(f"Exception while reading holding registers for address: '{slices[0].absolute_address}'!")
+            return False, None
+           
+    def write_register(self,value:int, address:int, check_connection:bool = True) -> bool:
+        """Write a value to the modbus server"""
+        if check_connection and not self.is_connected:
+            logging.error("Connection to modbus is not established!")
+            return False
+        try:
+            response = self.client.write_registers(address, [value], **self.__slave_args)
+            if response.isError():
+                logging.error(f"Error writing value={value} to register: {address}: {response}")
+                return False
+        except Exception:
+            logging.exception(f"Eception while writing value={value} to register: {address}!")
+            return False
+        return True
+        
+        
+        


### PR DESCRIPTION
This is a first draft of the changes mentioned in #13.

I tried to abstract the `update` method into the specific components. This allows me to easily work with lists of components e.g. update 4 different buffers.

I also tried to solve the problem with the setters for every holding value by creating a `commit` method that will write the current raw value of a DataValue to the modbus server.

With these changes the api could be used like this:
```python
from pysolarfocus import SolarfocusAPI,PORT,Systems

#the modbus client was moved into the api
solarfocus = SolarfocusAPI("IP",buffer_count=4,heating_circuit_count=2 ,system=Systems.Therminator)
solarfocus.connect()

#Updates all buffers
solarfocus.update_buffer()

#print all buffer
for buffer in solarfocus.buffers:
    print(buffer)

#print 3. buffer
print(solarfocus.buffers[2])

#Get Second Heating Circuit
hc_2 = solarfocus.heating_circuits[1]
#Set the value to 30 Degree
hc_2.indoor_temperatur_external.set_unscaled_value(30)
#write the value to the heating system
hc_2.indoor_temperatur_external.commit()
```

To implement this i had to refactor some of the scaling code, would be great if you could verify if the values are still correct for your system. I already tested it for mine and it seams to work.