### PR TITLE
Add pellet statistics

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,6 +6,8 @@
 
 This integration has been tested with Solarfocus eco<sup>manager-touch</sup> version `21.040`.
 
+Added biomass boiler pellet statistics (available since version 23.010)
+
 ### Systems
 
 * Heat pump vamp<sup>air</sup> with eco<sup>_manager-touch_</sup>

--- a/pysolarfocus/components/pellets_boiler.py
+++ b/pysolarfocus/components/pellets_boiler.py
@@ -1,10 +1,10 @@
 from .base.component import Component
-from .base.enums import DataTypes
+from .base.enums import DataTypes, RegisterTypes
 from .base.data_value import DataValue
 
 class PelletsBoiler(Component):
-    def __init__(self) -> None:
-        super().__init__(2400)
+    def __init__(self,input_address=2400,holding_address=33400) -> None:
+        super().__init__(self,input_address, holding_address)
         self.temperature = DataValue(address=0,multiplier=0.1)
         self.status  = DataValue(address=1,type=DataTypes.UINT)
         self.message_number = DataValue(address=4)
@@ -16,3 +16,7 @@ class PelletsBoiler(Component):
         self.octoplus_buffer_temperature_bottom = DataValue(address=10,multiplier=0.1)
         self.octoplus_buffer_temperature_top = DataValue(address=11,multiplier=0.1)
         self.log_wood = DataValue(address=12,type=DataTypes.UINT)
+        self.pellet_usage_last_fill = DataValue(address=14,type=DataTypes.UINT,multiplier=0.1)
+        self.pellet_usage_total = DataValue(address=16,type=DataTypes.UINT,multiplier=0.1)
+        self.heat_energy_total = DataValue(address=18,type=DataTypes.UINT,multiplier=0.1)
+        self.pellet_usage_reset = DataValue(address=12,type=DataTypes.UINT,register_type=RegisterTypes.Holding)


### PR DESCRIPTION
Adding new modbus values available since V23.010

- Pellet usage since last storage fill (in kg)
- pellet usage total (since upgrade to Version 21.050 or newer) (in kg)
- generated heat energy (total) (in kWh)
- reset pellet storage filled (flag)