### PR TITLE
Support multiple api versions

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,11 @@
 
 This integration has been tested with Solarfocus eco<sup>manager-touch</sup> version `21.040`.
 
-Added biomass boiler pellet statistics (available since version 23.010)
+Added biomass boiler pellet statistics (available since version 23.010). To have them available, choose the respective API version when instantiating the client:
+
+```python
+solarfocus = SolarfocusAPI(ip="[Your-IP]", system=Systems.Vampair, api_version=ApiVersions.V_23_010)
+```
 
 ### Systems
 

--- a/example.py
+++ b/example.py
@@ -1,8 +1,9 @@
-from pysolarfocus import SolarfocusAPI,Systems
+from pysolarfocus import SolarfocusAPI,Systems,ApiVersions
 
 # Create the Solarfocus API client
-# TODO: Adapt IP-Address
-solarfocus = SolarfocusAPI(ip="IP-Address", system=Systems.Therminator)
+# TODO: Choose either Vampair or Therminator and adapt IP-Address and version
+solarfocus = SolarfocusAPI(ip="IP-Address", system=Systems.Vampair, api_version=ApiVersions.V_21_140)
+
 solarfocus.connect()
 # Fetch the values
 solarfocus.update()
@@ -14,9 +15,10 @@ print(solarfocus.boilers[0])
 print("\n")
 print(solarfocus.buffers[0])
 print("\n")
-print(solarfocus.pelletsboiler)
-print("\n")
-print(solarfocus.heatpump)
+if solarfocus.system is Systems.Therminator:
+    print(solarfocus.pelletsboiler)
+if solarfocus.system is Systems.Vampair:
+    print(solarfocus.heatpump)
 print("\n")
 print(solarfocus.photovoltaic)
 print("\n")

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "pysolarfocus"
-version = "3.4.0"
+version = "3.5.0"
 description = "Unofficial, local Solarfocus client"
 authors = ["Jeroen Laverman <jjlaverman@web.de>"]
 license = "Apache-2.0"

--- a/pysolarfocus/__init__.py
+++ b/pysolarfocus/__init__.py
@@ -1,7 +1,8 @@
 """Python client lib for Solarfocus"""
-__version__ = "3.4.0"
+__version__ = "3.5.0"
 
 from enum import Enum
+from packaging import version
 
 #Default port for modbus
 PORT = 502
@@ -14,6 +15,10 @@ class Systems(str, Enum):
     Vampair = "Vampair"
     Therminator = "Therminator" 
     
+class ApiVersions(Enum):
+    V_21_140 = version.parse("21.140")
+    V_23_010 = version.parse("23.010")
+    
 from .modbus_wrapper import ModbusConnector
 from .component_factory import ComponentFactory
 from .const import SLAVE_ID
@@ -22,8 +27,12 @@ class SolarfocusAPI:
     """Solarfocus Heating System"""
     
     @property
-    def system(self): 
+    def system(self) -> Systems: 
         return self._system
+    
+    @property
+    def api_version(self) -> ApiVersions: 
+        return self.api_version
     
     def __init__(self,
                  ip:str,
@@ -32,7 +41,8 @@ class SolarfocusAPI:
                  boiler_count:int = 1,
                  system:Systems=Systems.Vampair,
                  port:int=PORT,
-                 slave_id:int=SLAVE_ID):
+                 slave_id:int=SLAVE_ID,
+                 api_version:ApiVersions=ApiVersions.V_21_140):
         """Initialize Solarfocus communication."""
         assert heating_circuit_count >= 0 and heating_circuit_count < 9, "Heating circuit count must be between 0 and 8"
         assert buffer_count >= 0 and buffer_count < 5, "Buffer count must be between 0 and 4"
@@ -47,10 +57,11 @@ class SolarfocusAPI:
         #Single components
         self.heatpump = self.__factory.heatpump(system)
         self.photovoltaic = self.__factory.photovoltaic(system)
-        self.pelletsboiler = self.__factory.pelletsboiler(system)
+        self.pelletsboiler = self.__factory.pelletsboiler(system,api_version)
         self.solar = self.__factory.solar(system)
         self._slave_id = slave_id
         self._system = system
+        self._api_vesion = api_version
     
     def connect(self):
         """Connect to Solarfocus eco manager-touch"""

--- a/pysolarfocus/__init__.py
+++ b/pysolarfocus/__init__.py
@@ -32,7 +32,7 @@ class SolarfocusAPI:
     
     @property
     def api_version(self) -> ApiVersions: 
-        return self.api_version
+        return self._api_version
     
     def __init__(self,
                  ip:str,
@@ -61,7 +61,7 @@ class SolarfocusAPI:
         self.solar = self.__factory.solar(system)
         self._slave_id = slave_id
         self._system = system
-        self._api_vesion = api_version
+        self._api_version = api_version
     
     def connect(self):
         """Connect to Solarfocus eco manager-touch"""

--- a/pysolarfocus/component_factory.py
+++ b/pysolarfocus/component_factory.py
@@ -6,7 +6,7 @@ from .components.pellets_boiler import *
 from .components.photovoltaic import *
 from .components.solar import *
 from .modbus_wrapper import ModbusConnector
-from . import Systems
+from . import Systems, ApiVersions
 
 
 class ComponentFactory:
@@ -53,8 +53,8 @@ class ComponentFactory:
     def photovoltaic(self, system:Systems)->Photovoltaic:
         return Photovoltaic()._initialize(self.__modbus_connector)
     
-    def pelletsboiler(self, system:Systems)->PelletsBoiler:
-        return PelletsBoiler()._initialize(self.__modbus_connector)
+    def pelletsboiler(self, system:Systems, api_version:ApiVersions)->PelletsBoiler:
+        return PelletsBoiler(api_version=api_version)._initialize(self.__modbus_connector)
     
     def solar(self, system:Systems)->Solar:
         return Solar()._initialize(self.__modbus_connector)

--- a/pysolarfocus/components/base/component.py
+++ b/pysolarfocus/components/base/component.py
@@ -1,10 +1,10 @@
 import logging
 
-from pysolarfocus.components.base.performance_calculator import PerformanceCalculator
 
 from ...modbus_wrapper import ModbusConnector
 from .data_value import DataValue
 from .enums import DataTypes, RegisterTypes
+from .performance_calculator import PerformanceCalculator
 from .register_slice import RegisterSlice
 
 

--- a/pysolarfocus/components/pellets_boiler.py
+++ b/pysolarfocus/components/pellets_boiler.py
@@ -1,9 +1,14 @@
 from .base.component import Component
 from .base.enums import DataTypes, RegisterTypes
 from .base.data_value import DataValue
+from .. import ApiVersions
 
 class PelletsBoiler(Component):
-    def __init__(self,input_address=2400,holding_address=33400) -> None:
+    def __init__(self,input_address=2400,holding_address=-1,api_version:ApiVersions=ApiVersions.V_21_140) -> None:
+        
+        if api_version.value >= ApiVersions.V_23_010.value:
+            holding_address=33400
+        
         super().__init__(input_address, holding_address)
         self.temperature = DataValue(address=0,multiplier=0.1)
         self.status  = DataValue(address=1,type=DataTypes.UINT)
@@ -16,7 +21,9 @@ class PelletsBoiler(Component):
         self.octoplus_buffer_temperature_bottom = DataValue(address=10,multiplier=0.1)
         self.octoplus_buffer_temperature_top = DataValue(address=11,multiplier=0.1)
         self.log_wood = DataValue(address=12,type=DataTypes.UINT)
-        self.pellet_usage_last_fill = DataValue(address=14,count=2,multiplier=0.1)
-        self.pellet_usage_total = DataValue(address=16,count=2,multiplier=0.1)
-        self.heat_energy_total = DataValue(address=18,count=2,multiplier=0.1)
-        self.pellet_usage_reset = DataValue(address=12,register_type=RegisterTypes.Holding)
+        
+        if api_version.value >= ApiVersions.V_23_010.value:
+            self.pellet_usage_last_fill = DataValue(address=14,count=2,multiplier=0.1)
+            self.pellet_usage_total = DataValue(address=16,count=2,multiplier=0.1)
+            self.heat_energy_total = DataValue(address=18,count=2,multiplier=0.1)
+            self.pellet_usage_reset = DataValue(address=12,register_type=RegisterTypes.Holding)


### PR DESCRIPTION
With system updates during maintenance, Solarfocus is adding new registers to their Modbus TCP API. In order to avoid incompatibilities with older versions (e.g. missing registers leading to errors), the library is extended to differentiate different versions. `21.140` being the default version and later versions have to be selected in order to access the respective registers. 